### PR TITLE
Remove empty left margin in notebooks

### DIFF
--- a/theme/static/stylesheet/kazunotebook.css
+++ b/theme/static/stylesheet/kazunotebook.css
@@ -8,8 +8,8 @@
 
 /* From http://nbviewer.jupyter.org/gist/HHammond/7a78d35b34d85406aa60 */
 
-/* 
-First block is for texts/code 
+/*
+First block is for texts/code
 */
 
 @import url('http://fonts.googleapis.com/css?family=Crimson+Text');
@@ -80,6 +80,7 @@ div.text_cell_render h3 {
 
 .prompt.input_prompt {
     color: rgba(0,0,0,0.5);
+    min-width: 0ex;
 }
 
 .cell.command_mode.selected {
@@ -144,8 +145,8 @@ div#notebook {
     font-weight: 200;
 }
 
-/* 
-    This is a lazy fix, we *should* fix the 
+/*
+    This is a lazy fix, we *should* fix the
     background for each Bootstrap button type
 */
 #site * .btn {
@@ -212,4 +213,3 @@ th {
 }
 
 tr:hover {background-color: gray}
-


### PR DESCRIPTION
I think the inner left margin that appears in all notebook posts is not very nice. This is a small fix to remove it and make all notebooks centered in the right column.

Before:
![margin](https://user-images.githubusercontent.com/10686637/46768640-d3ca9180-cc9d-11e8-8c60-d309bd2cdbb2.png)

After:
![margin2](https://user-images.githubusercontent.com/10686637/46768644-daf19f80-cc9d-11e8-889a-fc17b61ab562.png)

Of course if you disagree and prefer to keep the margin, please ignore this pull request!
